### PR TITLE
Potential fix for code scanning alert no. 2: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/shellc.c
+++ b/shellc.c
@@ -1561,7 +1561,7 @@ int main(int argc, char **argv)
             fprintf(stderr, "Failed to open the fix file: %s\n", file_name);
             return(1);
         }
-        stat(file_name, &status);
+        fstat(fileno(fix_file), &status);
         length = status.st_size;
         k = 0;
         for (j = 0; j < status.st_size; j++) {


### PR DESCRIPTION
Potential fix for [https://github.com/gdha/shellc/security/code-scanning/2](https://github.com/gdha/shellc/security/code-scanning/2)

To fix this TOCTOU vulnerability, replace the use of `stat(file_name, &status)` (which re-checks the metadata for whatever file now corresponds to `file_name`, which may have changed since opening) with `fstat(fileno(fix_file), &status)`. This ensures the metadata is gathered from the file actually opened with `fopen`, by its file descriptor, and eliminates the race condition.

Specifically, in `shellc.c`:

- At line 1564, replace `stat(file_name, &status);` with `fstat(fileno(fix_file), &status);`.
- Ensure you have included any needed headers or that they're already included: `#include <sys/stat.h>` and `<unistd.h>` are present.
- No other changes are required, as `fix_file` is already opened for reading and processed linearly.

No new methods or variable definitions are needed; only usage of `fstat` and `fileno` (already provided by POSIX standard).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
